### PR TITLE
fix to data patterns

### DIFF
--- a/nobrainerzoo/neuronets/brainy/brainy_train_spec.yaml
+++ b/nobrainerzoo/neuronets/brainy/brainy_train_spec.yaml
@@ -4,7 +4,10 @@ image:
   
 #### Train script
 train_script: Brainy_Train_Unet.py
-    
+
+# the sample data used if data_patterns is not provided by the user
+sample_data: sample_MGH
+
 #### general settings
 name: unet_brainy
 is_train: true
@@ -16,7 +19,6 @@ device: cuda:0
 #### datasets
 n_classes: 1
 dataset_train:
-  name: sample_MGH
   data_location: data/
   shuffle_buffer_size: 10
   block_shape: 32
@@ -26,7 +28,6 @@ dataset_train:
   n_train: 9
   num_parallel_calls: 2 # keeping same as batch sizse\
 dataset_test:     #  test params may differ from train params
-  name: sample_MGH
   data_location: data/
   shuffle_buffer_size: 0
   block_shape: 32

--- a/nobrainerzoo/neuronets/brainy/brainy_train_spec.yaml
+++ b/nobrainerzoo/neuronets/brainy/brainy_train_spec.yaml
@@ -23,6 +23,7 @@ dataset_train:
   volume_shape: 256
   batch_size: 2  # per GPU
   augment: False
+  n_train: 9
   num_parallel_calls: 2 # keeping same as batch sizse\
 dataset_test:     #  test params may differ from train params
   name: sample_MGH
@@ -31,6 +32,7 @@ dataset_test:     #  test params may differ from train params
   block_shape: 32
   volume_shape: 256
   batch_size: 1
+  n_test: 1
   num_parallel_calls: 1
   augment: False
 


### PR DESCRIPTION
- fixing `data_train/test_pattern` use: allowing the user to provide the patterns and using sample data if not provided; - 
- adding `sample_data` to the spec file (instead of the fields in the dataset_train/test) 
- updating the python script
- adding back n_test/n_train to the spec
- bringing back the singularity command, fixing bindings option